### PR TITLE
hotfix: interceptor에서 401 에러 처리시 서버 액션이 에러를 뱉는 문제 해결

### DIFF
--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -1,5 +1,4 @@
 import { getCookie } from "@/lib/cookie";
-import redirectAction from "@/lib/redirectAction";
 import axios from "axios";
 
 const instance = axios.create({
@@ -22,7 +21,10 @@ instance.interceptors.request.use(async (config) => {
 instance.interceptors.response.use(
   (response) => response,
   async (error) => {
-    if (error.response.status === 401) await redirectAction("/login");
+    if (error.response.status === 401) {
+      if (typeof window === "undefined") return error;
+      window.location.href = "/login";
+    }
     return Promise.reject(error);
   },
 );

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,8 +1,15 @@
 "use client";
 
+import { isAxiosError } from "axios";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 export default function Error({ error }: { error: Error }) {
+  const router = useRouter();
+  if (isAxiosError(error) && error.response?.status === 401) {
+    router.push("/login");
+    return null;
+  }
   return (
     <div className="flex h-screen flex-col items-center justify-center gap-8 bg-linkLanding bg-cover bg-center">
       <div className="flex items-center justify-center gap-2">

--- a/src/components/myPage/uncompletedMailScroll.tsx
+++ b/src/components/myPage/uncompletedMailScroll.tsx
@@ -65,7 +65,7 @@ export default function UncompletedMailScroll({ route }: MailScrollProps) {
               id,
               title,
               scheduledAt,
-              senderNickName,
+              senderNickname,
               description,
               bgmUrl,
               category,
@@ -76,7 +76,7 @@ export default function UncompletedMailScroll({ route }: MailScrollProps) {
                   <UncompletedMail
                     id={id}
                     title={title}
-                    nickName={senderNickName}
+                    nickName={senderNickname}
                     writtenDate={scheduledAt}
                     description={description}
                     bgmUrl={bgmUrl}

--- a/src/lib/redirectAction.ts
+++ b/src/lib/redirectAction.ts
@@ -1,5 +1,0 @@
-import { redirect } from "next/navigation";
-
-export default async function redirectAction(path: string) {
-  await redirect(path);
-}


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 #60 

- close #60 

## 🧱 작업 사항
- 서버 패칭과 클라이언트 패칭에서 401 에러가 발생했을 때 이를 감지하고 처리하는 에러 바운더리와 interceptor response를 구현하였습니다.

## 📸 결과물

## 💬 공유 포인트 및 논의 사항
