### PR TITLE
feat: 임시 저장 기능 구현

### DIFF
--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -1,4 +1,4 @@
-import { getCookie } from "@/lib/cookie";
+import { getCookie, removeCookie } from "@/lib/cookie";
 import axios from "axios";
 
 const instance = axios.create({
@@ -21,10 +21,7 @@ instance.interceptors.request.use(async (config) => {
 instance.interceptors.response.use(
   (response) => response,
   async (error) => {
-    if (error?.response?.status === 401) {
-      if (typeof window === "undefined") return error;
-      window.location.href = "/login";
-    }
+    if (error?.response?.status === 401) await removeCookie("token");
     return Promise.reject(error);
   },
 );

--- a/src/app/myPage/letterToMe/page.tsx
+++ b/src/app/myPage/letterToMe/page.tsx
@@ -26,18 +26,16 @@ export default async function Page({ searchParams }: PageProps) {
         <div className="text-center">내게 쓴 편지</div>
       </header>
       <section className="flex gap-2 px-5 py-3">
-        {CATEGORIES.map((categoryItem) => (
-          <Link
-            href={`/myPage/letterToMe?category=${categoryItem.value}`}
-            key={categoryItem.key}
-          >
-            <CategoryButton
-              key={categoryItem.key}
-              category={categoryItem}
-              currentCategory={category}
-            />
-          </Link>
-        ))}
+        <Link
+          href={`/myPage/letterToMe?category=${CATEGORIES[0].value}`}
+          key={CATEGORIES[0].key}
+        >
+          <CategoryButton
+            key={CATEGORIES[0].key}
+            category={CATEGORIES[0]}
+            currentCategory={category}
+          />
+        </Link>
       </section>
       <MailScroll route={`/letters/my/self?category=${category || ""}`} />
       <Footer />

--- a/src/app/myPage/page.tsx
+++ b/src/app/myPage/page.tsx
@@ -27,21 +27,13 @@ export default function Page() {
     }
   }, [router, logout]);
 
-  const handleBack = useCallback(() => {
-    router.back();
-  }, [router]);
-
   return (
     <>
       <header className="relative w-full pb-4 pt-[52px] text-center">
         <span className="block pb-4 text-Title01-SB text-line-700">
           마이페이지
         </span>
-        <button
-          type="button"
-          onClick={handleBack}
-          className="absolute right-4 top-[52px]"
-        >
+        <Link href="/home" className="absolute right-4 top-[52px]">
           <Image
             priority
             src="/icons/close.png"
@@ -49,7 +41,7 @@ export default function Page() {
             width={32}
             height={32}
           />
-        </button>
+        </Link>
         <section className="mt-5 flex flex-col items-center justify-center gap-4">
           {isPending && (
             <div className="h-[240px] w-[240px] animate-pulse rounded-full bg-[#d9d9d9]" />

--- a/src/app/myPage/uncompletedLetter/page.tsx
+++ b/src/app/myPage/uncompletedLetter/page.tsx
@@ -25,18 +25,16 @@ export default async function Page({ searchParams }: PageProps) {
         <div className="text-center">작성 중인 편지</div>
       </header>
       <section className="flex gap-2 px-5 py-3">
-        {CATEGORIES.map((categoryItem) => (
-          <Link
-            href={`/myPage/uncompletedLetter?category=${categoryItem.value}`}
-            key={categoryItem.key}
-          >
-            <CategoryButton
-              key={categoryItem.key}
-              category={categoryItem}
-              currentCategory={category}
-            />
-          </Link>
-        ))}
+        <Link
+          href={`/myPage/uncompletedLetter?category=${CATEGORIES[0].value}`}
+          key={CATEGORIES[0].key}
+        >
+          <CategoryButton
+            key={CATEGORIES[0].key}
+            category={CATEGORIES[0]}
+            currentCategory={category}
+          />
+        </Link>
       </section>
       <UncompletedMailScroll
         route={`/letters/drafts/paginated?category=${category || ""}`}

--- a/src/app/setNickName/page.tsx
+++ b/src/app/setNickName/page.tsx
@@ -31,7 +31,6 @@ const Page = () => {
   };
 
   useEffect(() => {
-    console.log(receiverNickName, myNickName);
     if (
       myNickName &&
       receiverNickName &&

--- a/src/app/signUp/page.tsx
+++ b/src/app/signUp/page.tsx
@@ -39,7 +39,6 @@ export default function SignUpPage() {
     // 데이터를 localStorage에 저장
     localStorage.setItem("signUpData", JSON.stringify(signUpData));
 
-    console.log("데이터 저장됨:", localStorage.getItem("signUpData")); // 확인용 로그
     router.push("/profile");
   };
 

--- a/src/app/writingLetter/page.tsx
+++ b/src/app/writingLetter/page.tsx
@@ -2,7 +2,7 @@
 
 /* eslint-disable react/no-array-index-key */
 import instance from "@/api/instance";
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import "../globals.css";
 import ImageUploader from "@/components/writingLetter/ImageUploader";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -16,6 +16,7 @@ import PopUp from "@/components/popUp";
 import Image from "next/image";
 import CalendarModal from "@/components/writingLetter/CalendarModal";
 import useImagePreview from "@/hooks/useImagePreview";
+import useSaveDraft from "@/hooks/useSaveDraft";
 
 const Page = () => {
   const overlay = useOverlay();
@@ -26,22 +27,69 @@ const Page = () => {
   const [title, setTitle] = useState<string>("");
   const [description, setDescription] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [draftId, setDraftId] = useState<number | null>(null);
 
   const router = useRouter();
   const searchParams = useSearchParams();
   const receiverId = searchParams.get("receiverId");
   const senderNickname = searchParams.get("senderNickname");
+  const draftMode = searchParams.get("draftMode");
   const { images, handleSelectImage } = useImagePreview(3);
 
   const [selectedMusicTitle, setSelectedMusicTitle] =
     useState<string>("노래 제목");
   const [selectedMusicUrl, setSelectedMusicUrl] = useState<string>("");
 
+  const handleInitialData = useCallback(
+    ({
+      title,
+      description,
+      scheduledAt,
+      bgmUrl,
+    }: {
+      title: string;
+      description: string;
+      scheduledAt: string;
+      bgmUrl: string;
+    }) => {
+      setTitle(title);
+      setDescription(description);
+      setSelectedDate(
+        scheduledAt
+          .split("-")
+          .map((item) => item.padStart(2, "0"))
+          .map((item, index) => item + ["년", "월", "일"][index])
+          .join(" "),
+      );
+      setSelectedMusicUrl(bgmUrl);
+      setSelectedMusicTitle(bgmUrl.split("/").pop() || "노래 제목");
+    },
+    [],
+  );
+
   const daysDifference = calculateDaysDifference(selectedDate);
   const formattedDate = formatDateStringToISO(selectedDate);
   const finalDate = selectedDate
     ? formattedDate
     : formatDateStringToISO(todayFormatted);
+
+  useEffect(() => {
+    if (!receiverId || !senderNickname) router.push("/home");
+  }, [receiverId, senderNickname, router]);
+
+  useSaveDraft({
+    delay: 10000,
+    bgmUrl: selectedMusicUrl,
+    description,
+    draftMode,
+    draftId,
+    setDraftId,
+    handleInitialData,
+    receiverId: receiverId ? Number(receiverId) : 0,
+    scheduledAt: finalDate,
+    senderNickname: senderNickname?.trim() || "익명의 친구",
+    title,
+  });
 
   const openMusicSelector = async () => {
     overlay.mount(
@@ -100,7 +148,10 @@ const Page = () => {
         senderNickName: senderNickname?.trim() || "익명의 친구",
       };
 
-      const response = await instance.post("/letters", payload);
+      const response = await instance.post(
+        draftId ? `/letters/draft/${draftId}/send` : "/letters",
+        payload,
+      );
       if (response.status === 201) router.push("/writingComplete");
     } catch (error) {
       console.error("편지 전송 실패:", error);

--- a/src/app/writingLetter/page.tsx
+++ b/src/app/writingLetter/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-/* eslint-disable react/no-array-index-key */
 import instance from "@/api/instance";
 import { useCallback, useEffect, useState } from "react";
 import "../globals.css";
@@ -190,6 +189,7 @@ const Page = () => {
           <div style={{ display: "flex", gap: 16 }}>
             {images.map((item, index) => (
               <ImageUploader
+                // eslint-disable-next-line react/no-array-index-key
                 key={index}
                 index={index}
                 previewUrl={item.previewUrl}
@@ -211,10 +211,10 @@ const Page = () => {
           </div>
         </header>
 
-        <div className="w-full flex-1">
+        <div className="flex w-full flex-1 flex-col">
           <textarea
             placeholder="내용을 입력하세요"
-            className="mt-4 h-[200px] w-full resize-none rounded-lg bg-transparent pl-4 pr-4 font-handwriting text-2xl text-black placeholder-grey-600 focus:outline-none"
+            className="mt-4 h-full w-full flex-1 resize-none rounded-lg bg-transparent px-4 font-handwriting text-2xl text-black placeholder-grey-600 focus:outline-none"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
           />

--- a/src/app/writingLetter/page.tsx
+++ b/src/app/writingLetter/page.tsx
@@ -26,7 +26,6 @@ const Page = () => {
   const [title, setTitle] = useState<string>("");
   const [description, setDescription] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [draftId, setDraftId] = useState<number | null>(null);
 
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -76,13 +75,11 @@ const Page = () => {
     if (!receiverId || !senderNickname) router.push("/home");
   }, [receiverId, senderNickname, router]);
 
-  useSaveDraft({
+  const [draftId, abortController] = useSaveDraft({
     delay: 10000,
     bgmUrl: selectedMusicUrl,
     description,
     draftMode,
-    draftId,
-    setDraftId,
     handleInitialData,
     receiverId: receiverId ? Number(receiverId) : 0,
     scheduledAt: finalDate,
@@ -147,6 +144,7 @@ const Page = () => {
         senderNickName: senderNickname?.trim() || "익명의 친구",
       };
 
+      abortController.current.abort();
       const response = await instance.post(
         draftId ? `/letters/draft/${draftId}/send` : "/letters",
         payload,

--- a/src/components/home/futureMail.tsx
+++ b/src/components/home/futureMail.tsx
@@ -2,7 +2,7 @@ import formateISODateToYYYYMMDD from "@/utils/formatDate";
 import Image from "next/image";
 
 interface FutureMailProps {
-  scheduledAt: string;
+  scheduledAt: string | null;
 }
 
 export default function FutureMail({ scheduledAt }: FutureMailProps) {
@@ -19,7 +19,9 @@ export default function FutureMail({ scheduledAt }: FutureMailProps) {
           sizes="48"
           priority
         />
-        <div className="text-center text-Body01-M text-grey-100">{`${formateISODateToYYYYMMDD(scheduledAt)}`}</div>
+        <div className="text-center text-Body01-M text-grey-100">
+          {scheduledAt && formateISODateToYYYYMMDD(scheduledAt)}
+        </div>
       </header>
     </section>
   );

--- a/src/components/home/mail.tsx
+++ b/src/components/home/mail.tsx
@@ -7,7 +7,7 @@ interface SealedMailProps {
   nickName: string;
   isOpen: boolean;
   id: number;
-  writtenDate: string;
+  scheduledAt: string | null;
 }
 
 export default function Mail({
@@ -15,7 +15,7 @@ export default function Mail({
   title,
   isOpen,
   id,
-  writtenDate,
+  scheduledAt,
 }: SealedMailProps) {
   return (
     <Link
@@ -35,7 +35,9 @@ export default function Mail({
           </div>
         </section>
         <footer className="absolute bottom-5 right-5 text-end font-handwriting text-Title01-R text-line-700">
-          <section>{formateISODateToYYYYMMDD(writtenDate)}</section>
+          <section>
+            {scheduledAt && formateISODateToYYYYMMDD(scheduledAt)}
+          </section>
           <section>{nickName} 보냄</section>
         </footer>
       </section>

--- a/src/components/home/mailScroll.tsx
+++ b/src/components/home/mailScroll.tsx
@@ -23,7 +23,7 @@ export default function MailScroll({ route }: MailScrollProps) {
   const router = useRouter();
   if (isError && !isCancelled)
     return (
-      <div className="mt-[120px] pb-[313px] text-center text-Body01-B text-grey-400">
+      <div className="mt-[120px] px-5 pb-[313px] text-center text-Body01-B text-grey-400">
         <div>편지를 불러오는 중에 오류가 발생했습니다.</div>
         <div className="text-grey-600">{error?.message}</div>
         <Image
@@ -53,11 +53,10 @@ export default function MailScroll({ route }: MailScrollProps) {
               title,
               isDelivered,
               scheduledAt,
-              createdAt,
               senderNickname,
               isOpen,
             }) => {
-              if (!isDelivered)
+              if (!isDelivered && scheduledAt)
                 return <FutureMail key={id} scheduledAt={scheduledAt} />;
               return (
                 <Mail
@@ -65,7 +64,7 @@ export default function MailScroll({ route }: MailScrollProps) {
                   id={id}
                   nickName={senderNickname}
                   title={title}
-                  writtenDate={createdAt}
+                  scheduledAt={scheduledAt}
                   isOpen={isOpen}
                 />
               );

--- a/src/components/myPage/uncompletedMail.tsx
+++ b/src/components/myPage/uncompletedMail.tsx
@@ -50,7 +50,6 @@ export default function UncompletedMail({
     searchParams.append("draftMode", "true");
     searchParams.append("receiverId", receiverId.toString());
     searchParams.append("senderNickname", senderNickname);
-    console.log(`/writingLetter?${searchParams.toString()}`);
     router.push(`/writingLetter?${searchParams.toString()}`);
   };
   return (

--- a/src/components/myPage/uncompletedMail.tsx
+++ b/src/components/myPage/uncompletedMail.tsx
@@ -1,48 +1,75 @@
+"use client";
+
 import Image from "next/image";
-import Link from "next/link";
-import { formateISODateToYYYYMMDDHHMM } from "../../utils/formatDate";
+import { useRouter } from "next/navigation";
+import { useLetterStore } from "@/providers/letterStoreProvider";
+import { formatDateStringToYYYYMMDD } from "@/utils/formatDate";
 
 interface UncompletedMailProps {
-  id: number;
+  draftId: number;
+  receiverId: number;
+  receiverNickName: string;
   title: string;
-  nickName: string;
-  writtenDate: string;
+  senderNickname: string;
+  scheduledAt: string;
   description: string;
   bgmUrl: string;
   category: "TEXT" | "VOICE";
-  imageUrl: string;
+  imageUrl: string[];
 }
 
-// TODO: 임시저장 로직 구현, 관련 정보를 전역 상태에 담고 이동
-/* eslint-disable */
 export default function UncompletedMail({
-  id,
-  nickName,
+  draftId,
+  receiverId,
+  receiverNickName,
+  senderNickname,
   title,
-  writtenDate,
+  scheduledAt,
   description,
   bgmUrl,
   category,
   imageUrl,
 }: UncompletedMailProps) {
+  const router = useRouter();
+  const setLetter = useLetterStore((store) => store.setLetter);
+
+  const handleClick = () => {
+    setLetter({
+      draftId,
+      title,
+      description,
+      imageUrl,
+      bgmUrl,
+      receiverId,
+      category,
+      scheduledAt,
+      senderNickname,
+      receiverNickName,
+    });
+    const searchParams = new URLSearchParams();
+    searchParams.append("draftMode", "true");
+    searchParams.append("receiverId", receiverId.toString());
+    searchParams.append("senderNickname", senderNickname);
+    console.log(`/writingLetter?${searchParams.toString()}`);
+    router.push(`/writingLetter?${searchParams.toString()}`);
+  };
   return (
-    <Link
-      href={`/writingLetter/${id}`}
+    <button
+      onClick={handleClick}
       className="relative mx-auto block h-[221px] w-[350px] selection:bg-none hover:opacity-70"
     >
       <Image src="/images/letter.png" alt="Mail" priority fill />
-      <section className="absolute h-full w-full" />
-      <section className="absolute h-full w-full">
+      <section className="relative h-full w-full">
         <section className="absolute left-0 right-0 top-9 flex items-center justify-center">
           <div className="w-[210px] truncate text-center text-Body01-M text-grey-900">
             {title}
           </div>
         </section>
         <footer className="absolute bottom-3 left-0 right-0 text-center text-Body02-M text-line-700">
-          <section>TO. {nickName}</section>
-          <section>{formateISODateToYYYYMMDDHHMM(writtenDate)}</section>
+          <section>TO. {receiverNickName}</section>
+          <section>{formatDateStringToYYYYMMDD(scheduledAt)}</section>
         </footer>
       </section>
-    </Link>
+    </button>
   );
 }

--- a/src/components/myPage/uncompletedMailScroll.tsx
+++ b/src/components/myPage/uncompletedMailScroll.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image";
 import useOverlay from "@/hooks/useoverlay";
 import { useRouter } from "next/navigation";
-import { GetLettersMyLettersResponse, Letter } from "@/types/letters";
+import { GetLettersDraftsPaginatedResponse } from "@/types/letters";
 import useInfiniteFetch from "@/hooks/useInfiniteFetch";
 import MailScrollSkeleton from "@/app/home/skeletons/mailScrollSkeleton";
 import useMutation from "@/hooks/useMutation";
@@ -27,16 +27,17 @@ export default function UncompletedMailScroll({ route }: MailScrollProps) {
     hasMore,
     isCancelled,
     setData,
-  } = useInfiniteFetch<GetLettersMyLettersResponse["items"][0]>({
+  } = useInfiniteFetch<GetLettersDraftsPaginatedResponse["items"][0]>({
     route,
   });
-  const { mutate } = useMutation<Letter>("/letters/draft", "delete");
+  const { mutate } =
+    useMutation<GetLettersDraftsPaginatedResponse["items"][0]>("delete");
   const router = useRouter();
   const overlay = useOverlay();
 
   if (isError && !isCancelled)
     return (
-      <div className="mt-[120px] pb-[313px] text-center text-Body01-B text-grey-400">
+      <div className="mt-[120px] px-5 pb-[313px] text-center text-Body01-B text-grey-400">
         <div>편지를 불러오는 중에 오류가 발생했습니다.</div>
         <div className="text-grey-600">{error?.message}</div>
         <Image
@@ -63,25 +64,31 @@ export default function UncompletedMailScroll({ route }: MailScrollProps) {
         ? data.map(
             ({
               id,
-              title,
-              scheduledAt,
-              senderNickname,
-              description,
-              bgmUrl,
-              category,
-              imageUrl,
+              draftData: {
+                receiverId,
+                title,
+                scheduledAt,
+                senderNickname,
+                description,
+                bgmUrl,
+                category,
+                imageUrls,
+              },
             }) => {
               return (
                 <section key={id} className="flex flex-col items-center gap-3">
                   <UncompletedMail
-                    id={id}
+                    draftId={id}
+                    receiverId={receiverId}
+                    // FIXME: receiverNickName 데이터 오면 수정
+                    receiverNickName={senderNickname}
                     title={title}
-                    nickName={senderNickname}
-                    writtenDate={scheduledAt}
+                    senderNickname={senderNickname}
+                    scheduledAt={scheduledAt}
                     description={description}
                     bgmUrl={bgmUrl}
                     category={category}
-                    imageUrl={imageUrl}
+                    imageUrl={imageUrls}
                   />
                   <section className="flex w-[350px] justify-end">
                     <button
@@ -104,7 +111,7 @@ export default function UncompletedMailScroll({ route }: MailScrollProps) {
                           );
                         });
                         if (isAgree)
-                          await mutate(data, {
+                          await mutate(data, `/letters/draft/${id}`, {
                             onMutate: () => {
                               setData((prev) =>
                                 prev

--- a/src/components/openLetter/OpenLetter.tsx
+++ b/src/components/openLetter/OpenLetter.tsx
@@ -44,9 +44,11 @@ export default function OpenLetter() {
         </div>
 
         <div className="relative flex w-full justify-center">
-          {letter?.imageUrl && (
-            <Image src={letter.imageUrl} alt="Letter Image" fill priority />
-          )}
+          {letter?.imageUrls &&
+            letter.imageUrls.map((url) => (
+              // FIXME: 백엔드 데이터가 바뀌어서 임시로 map을 사용
+              <Image key={url} src={url} alt="Letter Image" fill priority />
+            ))}
         </div>
       </main>
     </div>

--- a/src/hooks/useMutation.tsx
+++ b/src/hooks/useMutation.tsx
@@ -9,7 +9,6 @@ import { CanceledError, isAxiosError } from "axios";
 import instance from "@/api/instance";
 
 export default function useMutation<T, R = T>(
-  route: string,
   method: "post" | "put" | "delete",
 ) {
   const [isLoading, setIsLoading] = useState(false);
@@ -21,6 +20,7 @@ export default function useMutation<T, R = T>(
   const mutate = useCallback(
     async (
       data: T[],
+      route: string,
       {
         onDataHandler,
         onMutate,
@@ -46,7 +46,7 @@ export default function useMutation<T, R = T>(
         setIsLoading(false);
       }
     },
-    [route, method],
+    [method],
   );
 
   return { mutate, isLoading, isError, error, isCancelled };

--- a/src/hooks/useSaveDraft.tsx
+++ b/src/hooks/useSaveDraft.tsx
@@ -1,0 +1,131 @@
+import instance from "@/api/instance";
+import { useLetterStore } from "@/providers/letterStoreProvider";
+import { PostLettersDraftResponse } from "@/types/letters";
+import { CanceledError } from "axios";
+import { useEffect, useRef } from "react";
+
+interface useSaveDraftProps {
+  draftMode: string | null;
+  draftId: number | null;
+  setDraftId: (id: number) => void;
+  title: string;
+  description: string;
+  bgmUrl: string;
+  scheduledAt: string;
+  receiverId: number;
+  senderNickname: string;
+  delay: number;
+  handleInitialData: (data: {
+    title: string;
+    description: string;
+    scheduledAt: string;
+    bgmUrl: string;
+  }) => void;
+}
+
+export default function useSaveDraft({
+  bgmUrl,
+  description,
+  draftMode,
+  handleInitialData,
+  draftId,
+  setDraftId,
+  receiverId,
+  scheduledAt,
+  senderNickname,
+  title,
+  delay,
+}: useSaveDraftProps) {
+  const savedDraftId = useLetterStore((state) => state.draftId);
+  const savedTitle = useLetterStore((state) => state.title);
+  const savedDescription = useLetterStore((state) => state.description);
+  const savedBgmUrl = useLetterStore((state) => state.bgmUrl);
+  const savedScheduledAt = useLetterStore((state) => state.scheduledAt);
+  const currentExecuted = useRef<number>(Date.now());
+
+  useEffect(() => {
+    if (draftMode === "true" && savedDraftId) {
+      handleInitialData({
+        bgmUrl: savedBgmUrl,
+        description: savedDescription,
+        scheduledAt: savedScheduledAt,
+        title: savedTitle,
+      });
+      setDraftId(savedDraftId);
+    }
+  }, [
+    setDraftId,
+    draftMode,
+    savedBgmUrl,
+    savedDescription,
+    savedScheduledAt,
+    savedTitle,
+    handleInitialData,
+    savedDraftId,
+  ]);
+
+  // throttling으로 post, put 요청 보내는 훅
+  useEffect(() => {
+    const abortController = new AbortController();
+    if (Date.now() - currentExecuted.current > delay) {
+      currentExecuted.current = Date.now();
+      if (!draftId)
+        instance
+          .post<PostLettersDraftResponse>(
+            "/letters/draft",
+            {
+              title,
+              description,
+              imageUrls: [],
+              bgmUrl,
+              category: "TEXT",
+              scheduledAt,
+              receiverId,
+              senderNickname,
+            },
+            { signal: abortController.signal },
+          )
+          .then((res) => {
+            console.log(res.data.id);
+            if (res.status === 201) setDraftId(res.data.id);
+          })
+          .catch((err) => {
+            if (err instanceof CanceledError) return;
+            console.error(err);
+          });
+      else
+        instance
+          .put(
+            `/letters/draft/${draftId}`,
+            {
+              title,
+              description,
+              imageUrls: [],
+              bgmUrl,
+              category: "TEXT",
+              scheduledAt,
+              receiverId,
+              senderNickname,
+            },
+            { signal: abortController.signal },
+          )
+          .catch((err) => {
+            if (err instanceof CanceledError) return;
+            console.error(err);
+          });
+    }
+    return () => {
+      abortController.abort();
+    };
+  }, [
+    setDraftId,
+    delay,
+    bgmUrl,
+    description,
+    draftId,
+    receiverId,
+    scheduledAt,
+    senderNickname,
+    title,
+  ]);
+}

--- a/src/hooks/useSaveDraft.tsx
+++ b/src/hooks/useSaveDraft.tsx
@@ -2,12 +2,10 @@ import instance from "@/api/instance";
 import { useLetterStore } from "@/providers/letterStoreProvider";
 import { PostLettersDraftResponse } from "@/types/letters";
 import { CanceledError } from "axios";
-import { useEffect, useRef } from "react";
+import { RefObject, useEffect, useRef, useState } from "react";
 
 interface useSaveDraftProps {
   draftMode: string | null;
-  draftId: number | null;
-  setDraftId: (id: number) => void;
   title: string;
   description: string;
   bgmUrl: string;
@@ -28,20 +26,20 @@ export default function useSaveDraft({
   description,
   draftMode,
   handleInitialData,
-  draftId,
-  setDraftId,
   receiverId,
   scheduledAt,
   senderNickname,
   title,
   delay,
-}: useSaveDraftProps) {
+}: useSaveDraftProps): [number | null, RefObject<AbortController>] {
   const savedDraftId = useLetterStore((state) => state.draftId);
   const savedTitle = useLetterStore((state) => state.title);
   const savedDescription = useLetterStore((state) => state.description);
   const savedBgmUrl = useLetterStore((state) => state.bgmUrl);
   const savedScheduledAt = useLetterStore((state) => state.scheduledAt);
   const currentExecuted = useRef<number>(Date.now());
+  const abortControllerRef = useRef(new AbortController());
+  const [draftId, setDraftId] = useState<number | null>(null);
 
   useEffect(() => {
     if (draftMode === "true" && savedDraftId) {
@@ -66,7 +64,6 @@ export default function useSaveDraft({
 
   // throttling으로 post, put 요청 보내는 훅
   useEffect(() => {
-    const abortController = new AbortController();
     if (Date.now() - currentExecuted.current > delay) {
       currentExecuted.current = Date.now();
       if (!draftId)
@@ -83,10 +80,9 @@ export default function useSaveDraft({
               receiverId,
               senderNickname,
             },
-            { signal: abortController.signal },
+            { signal: abortControllerRef.current.signal },
           )
           .then((res) => {
-            console.log(res.data.id);
             if (res.status === 201) setDraftId(res.data.id);
           })
           .catch((err) => {
@@ -107,16 +103,13 @@ export default function useSaveDraft({
               receiverId,
               senderNickname,
             },
-            { signal: abortController.signal },
+            { signal: abortControllerRef.current.signal },
           )
           .catch((err) => {
             if (err instanceof CanceledError) return;
             console.error(err);
           });
     }
-    return () => {
-      abortController.abort();
-    };
   }, [
     setDraftId,
     delay,
@@ -128,4 +121,6 @@ export default function useSaveDraft({
     senderNickname,
     title,
   ]);
+
+  return [draftId, abortControllerRef];
 }

--- a/src/hooks/useVoiceUpload.tsx
+++ b/src/hooks/useVoiceUpload.tsx
@@ -13,7 +13,6 @@ const useVoiceUpload = (onUploadSuccess: (url: string) => void) => {
       const response = await instance.post("/letters/upload/voice", formData, {
         headers: { "Content-Type": "multipart/form-data" },
       });
-      console.log("업로드 응답:", response.data);
       const { voiceUrl } = response.data;
       onUploadSuccess(voiceUrl);
       return voiceUrl;

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -1,11 +1,13 @@
 import homeHandler from "./home";
 import letterToMeHandler from "./myPage/letterToMe";
 import uncompletedLetterHandler from "./myPage/uncompletedLetter";
+import writingLetterHandler from "./writingLetter";
 
 const handler = [
   ...uncompletedLetterHandler,
   ...letterToMeHandler,
   ...homeHandler,
+  ...writingLetterHandler,
 ];
 
 export default handler;

--- a/src/mocks/letter.ts
+++ b/src/mocks/letter.ts
@@ -1,4 +1,4 @@
-import { Letter } from "@/types/letters";
+import { GetLettersDraftsPaginatedResponse, Letter } from "@/types/letters";
 
 export const makeLetter: (id: number, category: "TEXT" | "VOICE") => Letter = (
   id,
@@ -16,11 +16,17 @@ export const makeLetter: (id: number, category: "TEXT" | "VOICE") => Letter = (
     title: "null",
     updatedAt: new Date().toISOString(),
     description: "null",
-    imageUrl: "null",
+    imageUrls: [],
     isDelivered: scheduledAt < new Date(),
-    isOpen: false,
-    scheduledAt: scheduledAt.toISOString(),
+    isOpen: Math.random() > 0.5,
+    scheduledAt: scheduledAt.toISOString().split("T")[0],
     senderNickname: "test",
+    receiver: {
+      email: "",
+      id: 1,
+      nickName: "test",
+      profileUrl: "null",
+    },
   };
 };
 
@@ -31,6 +37,76 @@ export const makePaginatedLetters = (
 ) => ({
   items: Array.from({ length: limit }, (_, i) =>
     makeLetter(i + 1 + (page - 1) * limit, category),
+  ),
+  meta: {
+    totalPages: 5,
+    total: 50,
+    page,
+    limit,
+  },
+});
+
+export const makePaginatedLettersWithDifferentCategory = (
+  page: number,
+  limit: number,
+) => ({
+  items: Array.from({ length: limit }, (_, i) => {
+    const newLetter = makeLetter(
+      i + 1 + (page - 1) * limit,
+      i % 2 === 0 ? "TEXT" : "VOICE",
+    );
+    newLetter.scheduledAt = null;
+    return newLetter;
+  }),
+  meta: {
+    totalPages: 5,
+    total: 50,
+    page,
+    limit,
+  },
+});
+
+export const makeDraft: (
+  id: number,
+) => GetLettersDraftsPaginatedResponse["items"][0] = (id) => {
+  const scheduledAt = new Date();
+  scheduledAt.setDate(
+    scheduledAt.getDate() + 5 - Math.floor(Math.random() * 10),
+  );
+  return {
+    draftData: {
+      bgmUrl: "null",
+      category: "TEXT",
+      createdAt: new Date().toISOString(),
+      id,
+      title: "새 편지",
+      updatedAt: new Date().toISOString(),
+      description: "null",
+      imageUrls: [],
+      receiverId: 1,
+      isOpen: false,
+      scheduledAt: scheduledAt.toISOString().split("T")[0],
+      senderNickname: "test",
+    },
+    category: "TEXT",
+    bgmUrl: "null",
+    receiverId: 1,
+    createdAt: new Date().toISOString(),
+    id,
+    title: "null",
+    updatedAt: new Date().toISOString(),
+    description: "null",
+    imageUrls: [],
+    isDelivered: scheduledAt < new Date(),
+    isOpen: false,
+    scheduledAt: scheduledAt.toISOString().split("T")[0],
+    senderNickname: "test",
+  };
+};
+
+export const makePaginatedDrafts = (page: number, limit: number) => ({
+  items: Array.from({ length: limit }, (_, i) =>
+    makeDraft(i + 1 + (page - 1) * limit),
   ),
   meta: {
     totalPages: 5,

--- a/src/mocks/myPage/letterToMe/index.ts
+++ b/src/mocks/myPage/letterToMe/index.ts
@@ -1,4 +1,4 @@
-import { makePaginatedLetters } from "@/mocks/letter";
+import { makePaginatedLettersWithDifferentCategory } from "@/mocks/letter";
 import { GetLettersMyLettersResponse } from "@/types/letters";
 import { http, HttpResponse } from "msw";
 
@@ -7,12 +7,10 @@ const letterToMeHandler = [
     const url = new URL(req.request.url);
     const page = url.searchParams.get("page");
     const limit = url.searchParams.get("limit");
-    const category = url.searchParams.get("category");
     return HttpResponse.json<GetLettersMyLettersResponse>(
-      makePaginatedLetters(
+      makePaginatedLettersWithDifferentCategory(
         parseInt(page || "1", 10),
         parseInt(limit || "1", 10),
-        category as "TEXT" | "VOICE",
       ),
     );
   }),

--- a/src/mocks/myPage/uncompletedLetter/index.ts
+++ b/src/mocks/myPage/uncompletedLetter/index.ts
@@ -1,5 +1,5 @@
-import { makePaginatedLetters } from "@/mocks/letter";
-import { GetLettersMyLettersResponse } from "@/types/letters";
+import { makePaginatedDrafts } from "@/mocks/letter";
+import { GetLettersDraftsPaginatedResponse } from "@/types/letters";
 import { http, HttpResponse } from "msw";
 
 const uncompletedLetterHandler = [
@@ -9,12 +9,10 @@ const uncompletedLetterHandler = [
       const url = new URL(req.request.url);
       const page = url.searchParams.get("page");
       const limit = url.searchParams.get("limit");
-      const category = url.searchParams.get("category");
-      return HttpResponse.json<GetLettersMyLettersResponse>(
-        makePaginatedLetters(
+      return HttpResponse.json<GetLettersDraftsPaginatedResponse>(
+        makePaginatedDrafts(
           parseInt(page || "1", 10),
           parseInt(limit || "1", 10),
-          category as "TEXT" | "VOICE",
         ),
       );
     },

--- a/src/mocks/writingLetter/index.ts
+++ b/src/mocks/writingLetter/index.ts
@@ -1,0 +1,43 @@
+import { http, HttpResponse } from "msw";
+import { GetLettersMyLettersResponse } from "@/types/letters";
+import { makePaginatedLetters } from "../letter";
+
+const writingLetterHandler = [
+  http.get<{ page: string; limit: string }>("/letters/my", (req) => {
+    const url = new URL(req.request.url);
+    const page = url.searchParams.get("page");
+    const limit = url.searchParams.get("limit");
+    const category = url.searchParams.get("category");
+    return HttpResponse.json<GetLettersMyLettersResponse>(
+      makePaginatedLetters(
+        parseInt(page || "1", 10),
+        parseInt(limit || "1", 10),
+        category as "TEXT" | "VOICE",
+      ),
+    );
+  }),
+  http.post("/letters", async ({ request }) => {
+    const newBody = await request.json();
+    console.log("전송된 데이터:", newBody);
+    return HttpResponse.json(null, { status: 201 });
+  }),
+  http.post("/letters/draft/:id/send", async ({ request, params }) => {
+    const newBody = await request.json();
+    const { id } = params;
+    console.log("전송된 데이터:", newBody, "params:", id);
+    return HttpResponse.json(null, { status: 201 });
+  }),
+  http.post("/letters/draft", async ({ request }) => {
+    const newBody = await request.json();
+    console.log("임시저장된 데이터:", newBody);
+    return HttpResponse.json({ id: 1 }, { status: 201 });
+  }),
+  http.put("/letters/draft/:id", async ({ request, params }) => {
+    const newBody = await request.json();
+    const { id } = params;
+    console.log("임시저장된 데이터:", newBody, "params:", id);
+    return HttpResponse.json(null, { status: 200 });
+  }),
+];
+
+export default writingLetterHandler;

--- a/src/stores/letterStore.ts
+++ b/src/stores/letterStore.ts
@@ -2,14 +2,16 @@ import { createJSONStorage, devtools, persist } from "zustand/middleware";
 import { createStore } from "zustand/vanilla";
 
 export type LetterState = {
+  draftId: number | null;
   title: string;
   description: string;
-  imageUrl: string;
+  imageUrl: string[];
   bgmUrl: string;
   receiverId: number;
   category: "TEXT" | "VOICE";
   scheduledAt: string;
-  senderNickName: string;
+  senderNickname: string;
+  receiverNickName: string;
 };
 
 export type LetterActions = {
@@ -20,14 +22,16 @@ export type LetterActions = {
 export type LetterStore = LetterState & LetterActions;
 
 export const defaultInitState: LetterState = {
+  draftId: null,
   title: "",
   description: "",
-  imageUrl: "",
+  imageUrl: [],
   bgmUrl: "",
   receiverId: 0,
   category: "TEXT",
   scheduledAt: "",
-  senderNickName: "",
+  senderNickname: "",
+  receiverNickName: "",
 };
 
 export const createLetterStore = (

--- a/src/types/letters.ts
+++ b/src/types/letters.ts
@@ -2,19 +2,117 @@ export type Letter = {
   id: number;
   title: string;
   description: string;
-  imageUrl: string;
+  imageUrls: string[];
   bgmUrl: string;
   category: "TEXT" | "VOICE";
+  isOpen: boolean;
+  isDelivered: boolean;
+  scheduledAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  senderNickname: string;
+  receiver: {
+    id: number;
+    email: string;
+    nickName: string;
+    profileUrl: string;
+  };
+};
+
+export interface GetLettersMyLettersResponse {
+  items: Letter[];
+  meta: {
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  };
+}
+
+export interface PostLettersRequest {
+  title: string;
+  description: string;
+  imageUrls: string[];
+  bgmUrl: string;
+  category: "TEXT" | "VOICE";
+  receiverId: number;
+  isOpen: false;
+  scheduledAt: string;
+  senderNickName: string;
+  audioUrl?: string;
+}
+
+export interface PostLettersDraftRequest {
+  title: string;
+  description: string;
+  imageUrls: [];
+  bgmUrl: string;
+  category: "TEXT";
+  receiverId: number;
+  scheduledAt: string;
+  senderNickName: string;
+}
+
+export interface PutLettersDraftIdRequest {
+  title: string;
+  description: string;
+  imageUrls: [];
+  bgmUrl: string;
+  category: "TEXT";
+  receiverId: number;
+  scheduledAt: string;
+  senderNickName: string;
+}
+
+export interface PostLettersDraftResponse {
+  id: number;
+  title: string;
+  description: string;
+  imageUrls: string[];
+  bgmUrl: string;
+  category: "TEXT";
   isOpen: boolean;
   isDelivered: boolean;
   scheduledAt: string;
   createdAt: string;
   updatedAt: string;
   senderNickname: string;
-};
+  isDraft: boolean;
+  draftData: {
+    title: string;
+    description: string;
+    imageUrls: string[];
+    bgmUrl: string;
+    category: "TEXT";
+    receiverId: number;
+    scheduledAt: string;
+    senderNickName: string;
+  };
+}
 
-export interface GetLettersMyLettersResponse {
-  items: Letter[];
+export interface GetLettersDraftsPaginatedResponse {
+  items: {
+    id: number;
+    title: string;
+    description: string;
+    imageUrls: string[];
+    bgmUrl: string;
+    category: "TEXT";
+    draftData: {
+      title: string;
+      description: string;
+      imageUrls: string[];
+      bgmUrl: string;
+      category: "TEXT";
+      receiverId: number;
+      scheduledAt: string;
+      senderNickname: string;
+    };
+    createdAt: string;
+    updatedAt: string;
+    senderNickname: string;
+    receiverId: number;
+  }[];
   meta: {
     total: number;
     page: number;

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -11,3 +11,8 @@ export function formateISODateToYYYYMMDDHHMM(date: string) {
   const [year, month, day] = YYYY_MM_DD.split("-");
   return `${year}. ${month}. ${day}. ${HH}:${MM}`;
 }
+
+export function formatDateStringToYYYYMMDD(date: string) {
+  const [year, month, day] = date.split("-");
+  return `${year}. ${month}. ${day}`;
+}


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성 -->

## 🏷️ 이슈 번호 #58 

- close #58 

## 🧱 작업 사항

- 미들웨어랑 interceptor.response.use 문제 때문에 발생한 무한 새로고침 문제를 해결했습니다. 이제 로그인 접근 제한은 미들웨어에서만 진행됩니다.
- letter 관련해서 mock 서버 코드를 더 작성하고 타입을 세팅했습니다.
- 간단한 에러들을 처리했어요.
- 쓰로틀링으로 임시저장 요청을 보내는 훅을 구현하고 이를 writingLetter에 적용했어요. 임시 저장의 초기 상태는 zustand가 갖고있고 이를 적용할지 판단하는 건 search Param의 draftMode입니다.

## 📸 결과물

## 💬 공유 포인트 및 논의 사항
- mock 서버에서는 정상적으로 돌아갔지만 아직 서버가 배포 문제 해결이 되지 않은 상태라서 실제 서버와 테스트 해보고 머지하겠습니다.